### PR TITLE
Ship TypeScript declarations for the public API

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -42,3 +42,12 @@ jobs:
 
       - name: Test
         run: npm test
+
+      # Both check lib/, so they run after the build. test:types compiles the
+      # fixtures in tests/types against the shipped declarations; test:exports
+      # checks that every way of loading the package resolves to them.
+      - name: Type declarations
+        run: npm run test:types
+
+      - name: Package exports
+        run: npm run test:exports

--- a/README.md
+++ b/README.md
@@ -45,6 +45,35 @@ production as it is smaller. Both ship with external source maps.
 > AMD/RequireJS is no longer supported as of 1.3.0. The bundles target ES2019, so
 > Internet Explorer is no longer supported either — use 1.2.x if you need either.
 
+### TypeScript
+
+Types ship with the package — there is no `@types/jalali-date` to install, and nothing
+to configure. The library itself stays JavaScript; the declarations are hand written in
+`types/jdate.d.ts` and emitted per module format, so `import` and `require` each get the
+shape they actually receive at runtime.
+
+```typescript
+import JDate, { type JalaliDate, type JDateConfig } from 'jalali-date';
+
+const jdate = new JDate([1396, 8, 26], { persianNumerical: true });
+const formatted: string = jdate.format('dddd DD MMMM YYYY');
+const parts: JalaliDate = jdate.date;
+```
+
+Under `require`, the same types come through a namespace on the class:
+
+```typescript
+import JDate = require('jalali-date');
+
+const config: JDate.JDateConfig = { persianNumerical: true };
+```
+
+The constructor is typed as four overloads, so the argument mistakes that fail quietly at
+runtime fail at compile time instead — `new JDate([1396, 8])` builds an Invalid Date
+rather than throwing, and is rejected here because `JalaliDate` is a three-element tuple.
+Config entry counts stay a runtime check, so that a name list inferred as `string[]`
+rather than as a fixed-length tuple can still be passed.
+
 ### Initialization
 
 For initializing `JDate` you may either pass an array of Jalali date to it or a `Date` object. If no parameter is passed, the default is today:
@@ -273,6 +302,18 @@ reach back into an existing instance.
 ## Contribute
 
 Report bugs and suggest feature in [issue tracker](https://github.com/arashm/Jalali-Calendar/issues). Feel free to `Fork` and send `Pull Requests`.
+
+| Script | What it does |
+| ------ | ------------ |
+| `npm test` | Runs the unit tests against `src/` |
+| `npm run lint` | ESLint over the sources, tests and scripts |
+| `npm run build` | Writes the bundles and declarations into `lib/` |
+| `npm run watch` | The same, rebuilding on change |
+| `npm run test:types` | Compiles `tests/types/` against the built declarations |
+| `npm run test:exports` | Checks that every way of importing the package resolves to types |
+
+The last two read `lib/`, so run `npm run build` first. Changing the public API means
+changing `types/jdate.d.ts` alongside `src/` — nothing generates one from the other.
 
 ## License
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,216 @@
+/*
+ * The public type surface, hand written and kept in step with src/ by hand.
+ *
+ * This file is a fragment, not a module: it deliberately ends without an export
+ * statement. scripts/build.mjs appends a per-format footer and writes the result
+ * into lib/ three times, because the shape a consumer sees depends on how they
+ * load the package:
+ *
+ *   lib/jdate.d.mts   export default JDate   matches lib/jdate.mjs
+ *   lib/jdate.d.cts   export = JDate         matches lib/jdate.cjs, whose build
+ *                                            footer unwraps .default away
+ *   lib/index.d.ts    export = JDate         the "types" field, for consumers
+ *                                            still on moduleResolution: node
+ *
+ * One shared `export default` would be wrong for two of those three: it would
+ * type `require('jalali-date')` as `{ default: JDate }` when the CJS bundle
+ * hands back the class itself. Nothing about that failure is loud — and it is
+ * past what `npm run test:exports` looks at, which is how the entry points
+ * resolve rather than what they export — so tests/types/node16.cts pins the
+ * shape by requiring the package the way a CommonJS consumer does.
+ *
+ * Types are generated from this file rather than from the JSDoc in src/ because
+ * the constructor is variadic there — `constructor(...args)` would emit
+ * `...args: any[]` and lose the four call forms below, which are the most
+ * useful thing here to type.
+ */
+
+/**
+ * A Jalali date as `[year, month, day]`.
+ *
+ * The month is one based — `1` is فروردین and `12` is اسفند — matching
+ * `getMonth()` and `setMonth()`, though not the zero based
+ * {@link JDate.daysInMonth}.
+ *
+ * The length is part of the type on purpose. `new JDate([1396, 8])` throws
+ * nothing at runtime; it quietly builds an Invalid Date, so the tuple is the
+ * only place that mistake can be caught.
+ */
+type JalaliDate = [year: number, month: number, day: number];
+
+/**
+ * What `format()` prints, layered over the app-wide default by
+ * {@link JDate.setDefaultConfig} or by the last argument to the constructor.
+ * Every key is optional; the ones you leave out keep their built-in values.
+ *
+ * Entry counts are checked at runtime rather than in the type, so that a list
+ * built elsewhere — inferred as `string[]` rather than as a fixed-length tuple —
+ * can still be passed. A wrong length throws at the call site.
+ */
+interface JDateConfig {
+  /** 12 entries in calendar order, فروردین first. */
+  monthNames?: readonly string[];
+  /** 7 entries indexed by `Date#getDay()`, so Sunday first — not Saturday. */
+  dayNames?: readonly string[];
+  /** 7 entries indexed by `Date#getDay()`, so Sunday first — not Saturday. */
+  abbrDays?: readonly string[];
+  /**
+   * Prints the numeric identifiers (`YYYY`, `MM`, `DD`, …) in Persian digits.
+   * Defaults to `false`; the name identifiers are unaffected either way.
+   */
+  persianNumerical?: boolean;
+}
+
+/**
+ * A config with every key filled in. This is what the static config methods
+ * return and what an instance holds as `config` — frozen at construction time,
+ * hence readonly throughout.
+ */
+interface ResolvedJDateConfig {
+  readonly monthNames: readonly string[];
+  readonly dayNames: readonly string[];
+  readonly abbrDays: readonly string[];
+  readonly persianNumerical: boolean;
+}
+
+declare class JDate {
+  /**
+   * Today's date, optionally with display overrides.
+   *
+   * @example new JDate({ persianNumerical: true })
+   */
+  // Not `JDateConfig | null`, unlike the forms below. A trailing null is
+  // dropped only when a whole date is left standing beside it, so `new
+  // JDate(null)` reaches none of the constructor's branches and throws
+  // "Unexpected input" — pass `{}` or nothing. Passing `undefined` explicitly
+  // throws for the same reason and cannot be typed out of reach: TypeScript
+  // lets `undefined` through any optional parameter.
+  constructor(config?: JDateConfig);
+
+  /**
+   * A Jalali date as `[year, month, day]` with a one-based month, or a
+   * Gregorian `Date` to convert.
+   *
+   * @example new JDate([1396, 8, 26])
+   * @example new JDate(new Date(), { monthNames })
+   */
+  constructor(date: JalaliDate | Date, config?: JDateConfig | null);
+
+  /**
+   * A Jalali date as three numbers, with a one-based month.
+   *
+   * @example new JDate(1396, 8, 26)
+   */
+  constructor(year: number, month: number, day: number, config?: JDateConfig | null);
+
+  /** The Jalali date as `[year, month, day]`. The setters write through to it. */
+  date: JalaliDate;
+
+  /**
+   * What the constructor was given, with any config argument stripped. The
+   * setters do not touch it, so it still reflects the original input after a
+   * `setMonth()`.
+   */
+  input: JalaliDate | Date;
+
+  /** The Gregorian equivalent, kept in sync by the setters. */
+  _d: Date;
+
+  /** The frozen display options this instance formats with. */
+  readonly config: ResolvedJDateConfig;
+
+  /** The Gregorian equivalent of this instance's date. */
+  toGregorian(): Date;
+
+  /** The Jalali year, ex: `1396`. */
+  getFullYear(): number;
+
+  /** Returns this instance, so setters chain. */
+  setFullYear(year: number): this;
+
+  /** The Jalali month, `1` to `12`. Unlike `Date#getMonth`, this is one based. */
+  getMonth(): number;
+
+  /**
+   * Sets the Jalali month. Unlike `Date#setMonth`, this is one based; values
+   * outside `1..12` roll the year over, so `setMonth(13)` is month `1` of the
+   * following year.
+   *
+   * @returns this instance, so setters chain.
+   */
+  setMonth(month: number): this;
+
+  /** The Jalali day of the month, `1` to `31`. */
+  getDate(): number;
+
+  /** Returns this instance, so setters chain. */
+  setDate(date: number): this;
+
+  /** The day of the week, `0` (Sunday) to `6` (Saturday), as `Date#getDay`. */
+  getDay(): number;
+
+  /**
+   * Formats the date. Identifiers: `YYYY`/`YYY`, `YY`, `MMMM`/`MMM`, `MM`, `M`,
+   * `DD`, `D`, `dddd`/`ddd`, `dd`/`d`. Anything else passes through, so wrap
+   * literal text containing an identifier character in square brackets —
+   * `format('[Day] D')`.
+   *
+   * The name identifiers resolve against this instance's config, which also
+   * decides whether the numeric ones print in ASCII or Persian digits.
+   *
+   * @example jdate.format('dddd DD MMMM YYYY') // => جمعه 26 آبان 1396
+   */
+  format(format: string): string;
+
+  /**
+   * Overrides what every later instance formats with. Replaces the default
+   * rather than merging into a previous call, so the result depends only on
+   * what you pass. Throws on an unknown key or a wrong-shaped value.
+   *
+   * Existing instances keep the config they captured at construction time.
+   */
+  static setDefaultConfig(config: JDateConfig): ResolvedJDateConfig;
+
+  /** The frozen config new instances will pick up. */
+  static getDefaultConfig(): ResolvedJDateConfig;
+
+  /** Restores the built-in Persian names and ASCII numerals. */
+  static resetDefaultConfig(): ResolvedJDateConfig;
+
+  /** Converts a Gregorian `Date` to a Jalali `[year, month, day]`. */
+  static toJalali(date: Date): JalaliDate;
+
+  /**
+   * @deprecated Renamed to {@link JDate.toJalali}; this alias is kept only for
+   * backwards compatibility.
+   */
+  static to_jalali(date: Date): JalaliDate;
+
+  /** Converts a Jalali date, with a one-based month, to a Gregorian `Date`. */
+  static toGregorian(year: number, month: number, day: number): Date;
+
+  /**
+   * @deprecated Renamed to {@link JDate.toGregorian}; this alias is kept only
+   * for backwards compatibility.
+   */
+  static to_gregorian(year: number, month: number, day: number): Date;
+
+  /** Whether a Jalali year is a leap year. */
+  static isLeapYear(year: number): boolean;
+
+  /**
+   * The length of a Jalali month.
+   *
+   * Note: `month` is **zero based** here (`0` is فروردین, `11` is اسفند),
+   * unlike `getMonth`/`setMonth`, so it does not compose directly with
+   * `getMonth()` — `daysInMonth(d.getFullYear(), d.getMonth() - 1)`.
+   * Out-of-range values carry into the year.
+   */
+  static daysInMonth(year: number, month: number): number;
+}
+
+declare namespace JDate {
+  export { JalaliDate, JDateConfig, ResolvedJDateConfig };
+}
+
+export = JDate;

--- a/lib/jdate.d.cts
+++ b/lib/jdate.d.cts
@@ -1,0 +1,216 @@
+/*
+ * The public type surface, hand written and kept in step with src/ by hand.
+ *
+ * This file is a fragment, not a module: it deliberately ends without an export
+ * statement. scripts/build.mjs appends a per-format footer and writes the result
+ * into lib/ three times, because the shape a consumer sees depends on how they
+ * load the package:
+ *
+ *   lib/jdate.d.mts   export default JDate   matches lib/jdate.mjs
+ *   lib/jdate.d.cts   export = JDate         matches lib/jdate.cjs, whose build
+ *                                            footer unwraps .default away
+ *   lib/index.d.ts    export = JDate         the "types" field, for consumers
+ *                                            still on moduleResolution: node
+ *
+ * One shared `export default` would be wrong for two of those three: it would
+ * type `require('jalali-date')` as `{ default: JDate }` when the CJS bundle
+ * hands back the class itself. Nothing about that failure is loud — and it is
+ * past what `npm run test:exports` looks at, which is how the entry points
+ * resolve rather than what they export — so tests/types/node16.cts pins the
+ * shape by requiring the package the way a CommonJS consumer does.
+ *
+ * Types are generated from this file rather than from the JSDoc in src/ because
+ * the constructor is variadic there — `constructor(...args)` would emit
+ * `...args: any[]` and lose the four call forms below, which are the most
+ * useful thing here to type.
+ */
+
+/**
+ * A Jalali date as `[year, month, day]`.
+ *
+ * The month is one based — `1` is فروردین and `12` is اسفند — matching
+ * `getMonth()` and `setMonth()`, though not the zero based
+ * {@link JDate.daysInMonth}.
+ *
+ * The length is part of the type on purpose. `new JDate([1396, 8])` throws
+ * nothing at runtime; it quietly builds an Invalid Date, so the tuple is the
+ * only place that mistake can be caught.
+ */
+type JalaliDate = [year: number, month: number, day: number];
+
+/**
+ * What `format()` prints, layered over the app-wide default by
+ * {@link JDate.setDefaultConfig} or by the last argument to the constructor.
+ * Every key is optional; the ones you leave out keep their built-in values.
+ *
+ * Entry counts are checked at runtime rather than in the type, so that a list
+ * built elsewhere — inferred as `string[]` rather than as a fixed-length tuple —
+ * can still be passed. A wrong length throws at the call site.
+ */
+interface JDateConfig {
+  /** 12 entries in calendar order, فروردین first. */
+  monthNames?: readonly string[];
+  /** 7 entries indexed by `Date#getDay()`, so Sunday first — not Saturday. */
+  dayNames?: readonly string[];
+  /** 7 entries indexed by `Date#getDay()`, so Sunday first — not Saturday. */
+  abbrDays?: readonly string[];
+  /**
+   * Prints the numeric identifiers (`YYYY`, `MM`, `DD`, …) in Persian digits.
+   * Defaults to `false`; the name identifiers are unaffected either way.
+   */
+  persianNumerical?: boolean;
+}
+
+/**
+ * A config with every key filled in. This is what the static config methods
+ * return and what an instance holds as `config` — frozen at construction time,
+ * hence readonly throughout.
+ */
+interface ResolvedJDateConfig {
+  readonly monthNames: readonly string[];
+  readonly dayNames: readonly string[];
+  readonly abbrDays: readonly string[];
+  readonly persianNumerical: boolean;
+}
+
+declare class JDate {
+  /**
+   * Today's date, optionally with display overrides.
+   *
+   * @example new JDate({ persianNumerical: true })
+   */
+  // Not `JDateConfig | null`, unlike the forms below. A trailing null is
+  // dropped only when a whole date is left standing beside it, so `new
+  // JDate(null)` reaches none of the constructor's branches and throws
+  // "Unexpected input" — pass `{}` or nothing. Passing `undefined` explicitly
+  // throws for the same reason and cannot be typed out of reach: TypeScript
+  // lets `undefined` through any optional parameter.
+  constructor(config?: JDateConfig);
+
+  /**
+   * A Jalali date as `[year, month, day]` with a one-based month, or a
+   * Gregorian `Date` to convert.
+   *
+   * @example new JDate([1396, 8, 26])
+   * @example new JDate(new Date(), { monthNames })
+   */
+  constructor(date: JalaliDate | Date, config?: JDateConfig | null);
+
+  /**
+   * A Jalali date as three numbers, with a one-based month.
+   *
+   * @example new JDate(1396, 8, 26)
+   */
+  constructor(year: number, month: number, day: number, config?: JDateConfig | null);
+
+  /** The Jalali date as `[year, month, day]`. The setters write through to it. */
+  date: JalaliDate;
+
+  /**
+   * What the constructor was given, with any config argument stripped. The
+   * setters do not touch it, so it still reflects the original input after a
+   * `setMonth()`.
+   */
+  input: JalaliDate | Date;
+
+  /** The Gregorian equivalent, kept in sync by the setters. */
+  _d: Date;
+
+  /** The frozen display options this instance formats with. */
+  readonly config: ResolvedJDateConfig;
+
+  /** The Gregorian equivalent of this instance's date. */
+  toGregorian(): Date;
+
+  /** The Jalali year, ex: `1396`. */
+  getFullYear(): number;
+
+  /** Returns this instance, so setters chain. */
+  setFullYear(year: number): this;
+
+  /** The Jalali month, `1` to `12`. Unlike `Date#getMonth`, this is one based. */
+  getMonth(): number;
+
+  /**
+   * Sets the Jalali month. Unlike `Date#setMonth`, this is one based; values
+   * outside `1..12` roll the year over, so `setMonth(13)` is month `1` of the
+   * following year.
+   *
+   * @returns this instance, so setters chain.
+   */
+  setMonth(month: number): this;
+
+  /** The Jalali day of the month, `1` to `31`. */
+  getDate(): number;
+
+  /** Returns this instance, so setters chain. */
+  setDate(date: number): this;
+
+  /** The day of the week, `0` (Sunday) to `6` (Saturday), as `Date#getDay`. */
+  getDay(): number;
+
+  /**
+   * Formats the date. Identifiers: `YYYY`/`YYY`, `YY`, `MMMM`/`MMM`, `MM`, `M`,
+   * `DD`, `D`, `dddd`/`ddd`, `dd`/`d`. Anything else passes through, so wrap
+   * literal text containing an identifier character in square brackets —
+   * `format('[Day] D')`.
+   *
+   * The name identifiers resolve against this instance's config, which also
+   * decides whether the numeric ones print in ASCII or Persian digits.
+   *
+   * @example jdate.format('dddd DD MMMM YYYY') // => جمعه 26 آبان 1396
+   */
+  format(format: string): string;
+
+  /**
+   * Overrides what every later instance formats with. Replaces the default
+   * rather than merging into a previous call, so the result depends only on
+   * what you pass. Throws on an unknown key or a wrong-shaped value.
+   *
+   * Existing instances keep the config they captured at construction time.
+   */
+  static setDefaultConfig(config: JDateConfig): ResolvedJDateConfig;
+
+  /** The frozen config new instances will pick up. */
+  static getDefaultConfig(): ResolvedJDateConfig;
+
+  /** Restores the built-in Persian names and ASCII numerals. */
+  static resetDefaultConfig(): ResolvedJDateConfig;
+
+  /** Converts a Gregorian `Date` to a Jalali `[year, month, day]`. */
+  static toJalali(date: Date): JalaliDate;
+
+  /**
+   * @deprecated Renamed to {@link JDate.toJalali}; this alias is kept only for
+   * backwards compatibility.
+   */
+  static to_jalali(date: Date): JalaliDate;
+
+  /** Converts a Jalali date, with a one-based month, to a Gregorian `Date`. */
+  static toGregorian(year: number, month: number, day: number): Date;
+
+  /**
+   * @deprecated Renamed to {@link JDate.toGregorian}; this alias is kept only
+   * for backwards compatibility.
+   */
+  static to_gregorian(year: number, month: number, day: number): Date;
+
+  /** Whether a Jalali year is a leap year. */
+  static isLeapYear(year: number): boolean;
+
+  /**
+   * The length of a Jalali month.
+   *
+   * Note: `month` is **zero based** here (`0` is فروردین, `11` is اسفند),
+   * unlike `getMonth`/`setMonth`, so it does not compose directly with
+   * `getMonth()` — `daysInMonth(d.getFullYear(), d.getMonth() - 1)`.
+   * Out-of-range values carry into the year.
+   */
+  static daysInMonth(year: number, month: number): number;
+}
+
+declare namespace JDate {
+  export { JalaliDate, JDateConfig, ResolvedJDateConfig };
+}
+
+export = JDate;

--- a/lib/jdate.d.mts
+++ b/lib/jdate.d.mts
@@ -1,0 +1,213 @@
+/*
+ * The public type surface, hand written and kept in step with src/ by hand.
+ *
+ * This file is a fragment, not a module: it deliberately ends without an export
+ * statement. scripts/build.mjs appends a per-format footer and writes the result
+ * into lib/ three times, because the shape a consumer sees depends on how they
+ * load the package:
+ *
+ *   lib/jdate.d.mts   export default JDate   matches lib/jdate.mjs
+ *   lib/jdate.d.cts   export = JDate         matches lib/jdate.cjs, whose build
+ *                                            footer unwraps .default away
+ *   lib/index.d.ts    export = JDate         the "types" field, for consumers
+ *                                            still on moduleResolution: node
+ *
+ * One shared `export default` would be wrong for two of those three: it would
+ * type `require('jalali-date')` as `{ default: JDate }` when the CJS bundle
+ * hands back the class itself. Nothing about that failure is loud — and it is
+ * past what `npm run test:exports` looks at, which is how the entry points
+ * resolve rather than what they export — so tests/types/node16.cts pins the
+ * shape by requiring the package the way a CommonJS consumer does.
+ *
+ * Types are generated from this file rather than from the JSDoc in src/ because
+ * the constructor is variadic there — `constructor(...args)` would emit
+ * `...args: any[]` and lose the four call forms below, which are the most
+ * useful thing here to type.
+ */
+
+/**
+ * A Jalali date as `[year, month, day]`.
+ *
+ * The month is one based — `1` is فروردین and `12` is اسفند — matching
+ * `getMonth()` and `setMonth()`, though not the zero based
+ * {@link JDate.daysInMonth}.
+ *
+ * The length is part of the type on purpose. `new JDate([1396, 8])` throws
+ * nothing at runtime; it quietly builds an Invalid Date, so the tuple is the
+ * only place that mistake can be caught.
+ */
+type JalaliDate = [year: number, month: number, day: number];
+
+/**
+ * What `format()` prints, layered over the app-wide default by
+ * {@link JDate.setDefaultConfig} or by the last argument to the constructor.
+ * Every key is optional; the ones you leave out keep their built-in values.
+ *
+ * Entry counts are checked at runtime rather than in the type, so that a list
+ * built elsewhere — inferred as `string[]` rather than as a fixed-length tuple —
+ * can still be passed. A wrong length throws at the call site.
+ */
+interface JDateConfig {
+  /** 12 entries in calendar order, فروردین first. */
+  monthNames?: readonly string[];
+  /** 7 entries indexed by `Date#getDay()`, so Sunday first — not Saturday. */
+  dayNames?: readonly string[];
+  /** 7 entries indexed by `Date#getDay()`, so Sunday first — not Saturday. */
+  abbrDays?: readonly string[];
+  /**
+   * Prints the numeric identifiers (`YYYY`, `MM`, `DD`, …) in Persian digits.
+   * Defaults to `false`; the name identifiers are unaffected either way.
+   */
+  persianNumerical?: boolean;
+}
+
+/**
+ * A config with every key filled in. This is what the static config methods
+ * return and what an instance holds as `config` — frozen at construction time,
+ * hence readonly throughout.
+ */
+interface ResolvedJDateConfig {
+  readonly monthNames: readonly string[];
+  readonly dayNames: readonly string[];
+  readonly abbrDays: readonly string[];
+  readonly persianNumerical: boolean;
+}
+
+declare class JDate {
+  /**
+   * Today's date, optionally with display overrides.
+   *
+   * @example new JDate({ persianNumerical: true })
+   */
+  // Not `JDateConfig | null`, unlike the forms below. A trailing null is
+  // dropped only when a whole date is left standing beside it, so `new
+  // JDate(null)` reaches none of the constructor's branches and throws
+  // "Unexpected input" — pass `{}` or nothing. Passing `undefined` explicitly
+  // throws for the same reason and cannot be typed out of reach: TypeScript
+  // lets `undefined` through any optional parameter.
+  constructor(config?: JDateConfig);
+
+  /**
+   * A Jalali date as `[year, month, day]` with a one-based month, or a
+   * Gregorian `Date` to convert.
+   *
+   * @example new JDate([1396, 8, 26])
+   * @example new JDate(new Date(), { monthNames })
+   */
+  constructor(date: JalaliDate | Date, config?: JDateConfig | null);
+
+  /**
+   * A Jalali date as three numbers, with a one-based month.
+   *
+   * @example new JDate(1396, 8, 26)
+   */
+  constructor(year: number, month: number, day: number, config?: JDateConfig | null);
+
+  /** The Jalali date as `[year, month, day]`. The setters write through to it. */
+  date: JalaliDate;
+
+  /**
+   * What the constructor was given, with any config argument stripped. The
+   * setters do not touch it, so it still reflects the original input after a
+   * `setMonth()`.
+   */
+  input: JalaliDate | Date;
+
+  /** The Gregorian equivalent, kept in sync by the setters. */
+  _d: Date;
+
+  /** The frozen display options this instance formats with. */
+  readonly config: ResolvedJDateConfig;
+
+  /** The Gregorian equivalent of this instance's date. */
+  toGregorian(): Date;
+
+  /** The Jalali year, ex: `1396`. */
+  getFullYear(): number;
+
+  /** Returns this instance, so setters chain. */
+  setFullYear(year: number): this;
+
+  /** The Jalali month, `1` to `12`. Unlike `Date#getMonth`, this is one based. */
+  getMonth(): number;
+
+  /**
+   * Sets the Jalali month. Unlike `Date#setMonth`, this is one based; values
+   * outside `1..12` roll the year over, so `setMonth(13)` is month `1` of the
+   * following year.
+   *
+   * @returns this instance, so setters chain.
+   */
+  setMonth(month: number): this;
+
+  /** The Jalali day of the month, `1` to `31`. */
+  getDate(): number;
+
+  /** Returns this instance, so setters chain. */
+  setDate(date: number): this;
+
+  /** The day of the week, `0` (Sunday) to `6` (Saturday), as `Date#getDay`. */
+  getDay(): number;
+
+  /**
+   * Formats the date. Identifiers: `YYYY`/`YYY`, `YY`, `MMMM`/`MMM`, `MM`, `M`,
+   * `DD`, `D`, `dddd`/`ddd`, `dd`/`d`. Anything else passes through, so wrap
+   * literal text containing an identifier character in square brackets —
+   * `format('[Day] D')`.
+   *
+   * The name identifiers resolve against this instance's config, which also
+   * decides whether the numeric ones print in ASCII or Persian digits.
+   *
+   * @example jdate.format('dddd DD MMMM YYYY') // => جمعه 26 آبان 1396
+   */
+  format(format: string): string;
+
+  /**
+   * Overrides what every later instance formats with. Replaces the default
+   * rather than merging into a previous call, so the result depends only on
+   * what you pass. Throws on an unknown key or a wrong-shaped value.
+   *
+   * Existing instances keep the config they captured at construction time.
+   */
+  static setDefaultConfig(config: JDateConfig): ResolvedJDateConfig;
+
+  /** The frozen config new instances will pick up. */
+  static getDefaultConfig(): ResolvedJDateConfig;
+
+  /** Restores the built-in Persian names and ASCII numerals. */
+  static resetDefaultConfig(): ResolvedJDateConfig;
+
+  /** Converts a Gregorian `Date` to a Jalali `[year, month, day]`. */
+  static toJalali(date: Date): JalaliDate;
+
+  /**
+   * @deprecated Renamed to {@link JDate.toJalali}; this alias is kept only for
+   * backwards compatibility.
+   */
+  static to_jalali(date: Date): JalaliDate;
+
+  /** Converts a Jalali date, with a one-based month, to a Gregorian `Date`. */
+  static toGregorian(year: number, month: number, day: number): Date;
+
+  /**
+   * @deprecated Renamed to {@link JDate.toGregorian}; this alias is kept only
+   * for backwards compatibility.
+   */
+  static to_gregorian(year: number, month: number, day: number): Date;
+
+  /** Whether a Jalali year is a leap year. */
+  static isLeapYear(year: number): boolean;
+
+  /**
+   * The length of a Jalali month.
+   *
+   * Note: `month` is **zero based** here (`0` is فروردین, `11` is اسفند),
+   * unlike `getMonth`/`setMonth`, so it does not compose directly with
+   * `getMonth()` — `daysInMonth(d.getFullYear(), d.getMonth() - 1)`.
+   * Out-of-range values carry into the year.
+   */
+  static daysInMonth(year: number, month: number): number;
+}
+
+export default JDate;
+export type { JalaliDate, JDateConfig, ResolvedJDateConfig };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,98 @@
       "version": "1.4.0",
       "license": "MIT",
       "devDependencies": {
+        "@arethetypeswrong/cli": "^0.18.5",
         "@eslint/js": "^10.0.1",
         "@vitest/eslint-plugin": "^1.6.24",
         "esbuild": "^0.28.1",
         "eslint": "^10.8.0",
         "eslint-plugin-import-x": "^4.17.1",
         "globals": "^17.8.0",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.10"
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@andrewbranch/untar.js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@andrewbranch/untar.js/-/untar.js-1.0.3.tgz",
+      "integrity": "sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==",
+      "dev": true
+    },
+    "node_modules/@arethetypeswrong/cli": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/cli/-/cli-0.18.5.tgz",
+      "integrity": "sha512-gM+8vRsQOD/Uc7EnBedUhkG5OCsDWE4uoak5QvomGpMpaky0Eh41p04nIMgrWb8EOmqZUJGc6zz9hsP6E56R7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@arethetypeswrong/core": "0.18.5",
+        "chalk": "^4.1.2",
+        "cli-table3": "^0.6.3",
+        "commander": "^10.0.1",
+        "marked": "^9.1.2",
+        "marked-terminal": "^7.1.0",
+        "semver": "^7.5.4"
+      },
+      "bin": {
+        "attw": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arethetypeswrong/core": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.18.5.tgz",
+      "integrity": "sha512-9ytjzGwxjm9Uz7I9avfbt5vlQt6uk9uRRESzJjqrznl6WKvI6dwYTo+vJ3U02Wrq/mR3iql/PzhvHhKdJIAjDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@andrewbranch/untar.js": "^1.0.3",
+        "@loaderkit/resolve": "^1.0.2",
+        "cjs-module-lexer": "^1.2.3",
+        "fflate": "^0.8.3",
+        "lru-cache": "^11.0.1",
+        "semver": "^7.5.4",
+        "typescript": "5.6.1-rc",
+        "validate-npm-package-name": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@arethetypeswrong/core/node_modules/typescript": {
+      "version": "5.6.1-rc",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.1-rc.tgz",
+      "integrity": "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@braidai/lang": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@braidai/lang/-/lang-1.1.2.tgz",
+      "integrity": "sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@emnapi/core": {
@@ -698,6 +780,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@loaderkit/resolve": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@loaderkit/resolve/-/resolve-1.0.6.tgz",
+      "integrity": "sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@braidai/lang": "^1.0.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -1042,6 +1134,19 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -1768,6 +1873,58 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1809,6 +1966,120 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-highlight": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "highlight.js": "^10.7.1",
+        "mz": "^2.4.0",
+        "parse5": "^5.1.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.0",
+        "yargs": "^16.0.0"
+      },
+      "bin": {
+        "highlight": "bin/highlight"
+      },
+      "engines": {
+        "node": ">=8.0.0",
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/comment-parser": {
@@ -1878,6 +2149,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emojilib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
@@ -1925,6 +2223,16 @@
         "@esbuild/win32-arm64": "0.28.1",
         "@esbuild/win32-ia32": "0.28.1",
         "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2265,6 +2573,13 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2314,6 +2629,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
@@ -2353,6 +2678,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2381,6 +2726,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -2721,6 +3076,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2729,6 +3094,54 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
+      "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/marked-terminal": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.3.0.tgz",
+      "integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "ansi-regex": "^6.1.0",
+        "chalk": "^5.4.1",
+        "cli-highlight": "^2.1.11",
+        "cli-table3": "^0.6.5",
+        "node-emoji": "^2.2.0",
+        "supports-hyperlinks": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "marked": ">=1 <16"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/minimatch": {
@@ -2753,6 +3166,18 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.16",
@@ -2795,6 +3220,32 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-emoji": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+      "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.6.0",
+        "char-regex": "^1.0.2",
+        "emojilib": "^2.4.0",
+        "skin-tone": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.4",
@@ -2843,6 +3294,30 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^6.0.1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -2940,6 +3415,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -3027,6 +3512,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/skin-tone": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+      "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unicode-emoji-modifier-base": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3060,6 +3558,97 @@
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -3145,13 +3734,22 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/unicode-emoji-modifier-base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+      "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/unrs-resolver": {
@@ -3200,6 +3798,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
+      "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/vite": {
@@ -3411,6 +4019,63 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
+      "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "lint": "eslint . --cache",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:types": "tsc -p tests/types/tsconfig.json && tsc -p tests/types/tsconfig.bundler.json",
+    "test:exports": "attw --pack .",
     "build": "node scripts/build.mjs",
     "watch": "node scripts/build.mjs --watch",
     "prepack": "node scripts/build.mjs"
@@ -16,12 +18,19 @@
   },
   "main": "./lib/jdate.cjs",
   "module": "./lib/jdate.mjs",
+  "types": "./lib/index.d.ts",
   "unpkg": "./lib/jdate.min.js",
   "jsdelivr": "./lib/jdate.min.js",
   "exports": {
     ".": {
-      "import": "./lib/jdate.mjs",
-      "require": "./lib/jdate.cjs",
+      "import": {
+        "types": "./lib/jdate.d.mts",
+        "default": "./lib/jdate.mjs"
+      },
+      "require": {
+        "types": "./lib/jdate.d.cts",
+        "default": "./lib/jdate.cjs"
+      },
       "default": "./lib/jdate.cjs"
     },
     "./lib/*": "./lib/*",
@@ -49,12 +58,14 @@
   },
   "homepage": "https://github.com/arashm/JDate",
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.18.5",
     "@eslint/js": "^10.0.1",
     "@vitest/eslint-plugin": "^1.6.24",
     "esbuild": "^0.28.1",
     "eslint": "^10.8.0",
     "eslint-plugin-import-x": "^4.17.1",
     "globals": "^17.8.0",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.10"
   }
 }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -14,9 +14,12 @@
  * JDate is a default export, so the CJS and IIFE bundles would otherwise expose
  * a module namespace object ({ default: JDate }) rather than the class. Each one
  * gets a footer that unwraps it, preserving the interop the webpack build had.
+ *
+ * The TypeScript declarations are emitted the same way, from the hand-written
+ * body in types/jdate.d.ts plus a footer per export shape — see DECLARATIONS.
  */
 
-import { rm, mkdir } from 'node:fs/promises';
+import { rm, mkdir, readFile, writeFile, watch as watchPath } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as esbuild from 'esbuild';
@@ -76,13 +79,85 @@ const bundles = [
 
 const options = ({ label, ...rest }) => ({ ...shared, ...rest });
 
+const declarationDir = path.join(root, 'types');
+const declarationSource = path.join(declarationDir, 'jdate.d.ts');
+
+// The types declared alongside the class in types/jdate.d.ts. Both footers have
+// to name them, so they are written once here.
+const EXPORTED_TYPES = 'JalaliDate, JDateConfig, ResolvedJDateConfig';
+
+/*
+ * lib/jdate.mjs exports the class as `default` and nothing besides, so the named
+ * exports here are types only: they are erased at compile time and so cannot be
+ * mistaken for runtime bindings that do not exist.
+ */
+const ESM_FOOTER = `export default JDate;
+export type { ${EXPORTED_TYPES} };
+`;
+
+/*
+ * lib/jdate.cjs assigns the class straight onto module.exports, so `export =` is
+ * the shape that matches. It rules out every other top-level export, which is
+ * why the types travel through a namespace merged into the class instead:
+ * `import JDate = require('jalali-date')` reaches them as JDate.JDateConfig.
+ */
+const CJS_FOOTER = `declare namespace JDate {
+  export { ${EXPORTED_TYPES} };
+}
+
+export = JDate;
+`;
+
+/*
+ * index.d.ts holds the CJS declarations under a third name, for the top-level
+ * "types" field to point at. It looks redundant beside jdate.d.cts and is not:
+ * "types" is what consumers on moduleResolution: node read, and TypeScript did
+ * not learn the .d.cts extension until 4.7, so aiming the field straight at
+ * jdate.d.cts leaves every older version with no types at all — 4.6 reports
+ * "Could not find a declaration file for module 'jalali-date'". It describes
+ * the CJS bundle because "main" does too.
+ */
+const DECLARATIONS = [
+  { outfile: 'jdate.d.mts', footer: ESM_FOOTER },
+  { outfile: 'jdate.d.cts', footer: CJS_FOOTER },
+  { outfile: 'index.d.ts', footer: CJS_FOOTER }
+];
+
+async function buildDeclarations() {
+  const body = await readFile(declarationSource, 'utf8');
+
+  await Promise.all(DECLARATIONS.map(({ outfile, footer }) => (
+    writeFile(path.join(outDir, outfile), `${body}\n${footer}`)
+  )));
+}
+
 async function buildOnce() {
   await rm(outDir, { recursive: true, force: true });
   await mkdir(outDir, { recursive: true });
 
-  await Promise.all(bundles.map((bundle) => esbuild.build(options(bundle))));
+  await Promise.all([
+    ...bundles.map((bundle) => esbuild.build(options(bundle))),
+    buildDeclarations()
+  ]);
 
-  console.log(`built ${bundles.map((b) => b.label).join(', ')} -> lib/`);
+  const built = [...bundles.map((b) => b.label), 'types'];
+  console.log(`built ${built.join(', ')} -> lib/`);
+}
+
+/*
+ * esbuild's watcher only knows about the module graph rooted at src/, which the
+ * declarations are not part of, so they get their own. Left unawaited: it runs
+ * until the process is killed, alongside the esbuild contexts.
+ *
+ * The directory is watched rather than the file, because an editor that saves by
+ * writing a temporary file and renaming it over the original leaves a watch on
+ * the path itself pointing at an inode nothing will touch again.
+ */
+async function watchDeclarations() {
+  for await (const change of watchPath(declarationDir)) {
+    await buildDeclarations();
+    console.log(`rebuilt types -> lib/ (${change.filename})`);
+  }
 }
 
 async function watch() {
@@ -93,8 +168,13 @@ async function watch() {
   );
 
   await Promise.all(contexts.map((ctx) => ctx.watch()));
+  await buildDeclarations();
 
-  console.log('watching src/ for changes, ctrl-c to stop');
+  watchDeclarations().catch((error) => {
+    console.error(`declaration watch stopped: ${error.message}`);
+  });
+
+  console.log('watching src/ and types/ for changes, ctrl-c to stop');
 }
 
 if (process.argv.includes('--watch')) {

--- a/tests/types/bundler.ts
+++ b/tests/types/bundler.ts
@@ -1,0 +1,22 @@
+/*
+ * The same package seen through moduleResolution: bundler — what Vite, webpack
+ * and esbuild set up. It reads the "exports" map but always takes the "import"
+ * condition, regardless of the importing file's format, so this checks that
+ * lib/jdate.d.mts is what a bundled consumer gets.
+ *
+ * A thinner fixture than node16.mts on purpose: the declarations are the same
+ * file, so what is worth repeating here is the resolution, not the API.
+ */
+
+import JDate from 'jalali-date';
+import type { JalaliDate, JDateConfig, ResolvedJDateConfig } from 'jalali-date';
+
+const config: JDateConfig = { persianNumerical: true };
+const jdate = new JDate([1396, 8, 26], config);
+
+const formatted: string = jdate.format('dddd DD MMMM YYYY');
+const parts: JalaliDate = jdate.date;
+const resolved: ResolvedJDateConfig = jdate.config;
+
+// @ts-expect-error the config is validated at runtime; unknown keys throw
+const typo = new JDate({ persianNumeric: true });

--- a/tests/types/node16.cts
+++ b/tests/types/node16.cts
@@ -1,0 +1,28 @@
+/*
+ * The require() side. lib/jdate.cjs ends with
+ *
+ *   module.exports = module.exports.default
+ *
+ * so `require('jalali-date')` hands back the class itself, and the declaration
+ * it resolves to — lib/jdate.d.cts — has to say `export = JDate` for that.
+ * Were it a plain `export default` instead, the assignment below would be typed
+ * as a module namespace object and every use of it here would fail.
+ */
+
+import JDate = require('jalali-date');
+
+const jdate = new JDate([1396, 8, 26]);
+const formatted: string = jdate.format('YYYY/MM/DD');
+const year: number = jdate.getFullYear();
+const gregorian: Date = JDate.toGregorian(1396, 8, 26);
+
+/*
+ * `export =` allows no other top-level export, so the types ride along on a
+ * namespace merged into the class rather than as named exports.
+ */
+const config: JDate.JDateConfig = { persianNumerical: true };
+const resolved: JDate.ResolvedJDateConfig = JDate.setDefaultConfig(config);
+const jalali: JDate.JalaliDate = JDate.toJalali(new Date());
+
+// @ts-expect-error the bundle unwraps .default away, so there is no such property
+const unwrapped = JDate.default;

--- a/tests/types/node16.mts
+++ b/tests/types/node16.mts
@@ -1,0 +1,128 @@
+/*
+ * The main type fixture. Nothing here runs — `tsc --noEmit` compiling it
+ * cleanly is the assertion, and every `@ts-expect-error` is the opposite one:
+ * tsc reports an unused directive if the line below it stops being an error.
+ *
+ * Being a .mts file, this resolves "jalali-date" through the "import" condition
+ * of the exports map, so what it checks is lib/jdate.d.mts.
+ */
+
+import JDate from 'jalali-date';
+import type { JalaliDate, JDateConfig, ResolvedJDateConfig } from 'jalali-date';
+
+/*
+ * Assignability is too weak on its own here: `any` is assignable to everything,
+ * so a declaration that had quietly degraded to `any` would pass. This compares
+ * types exactly, by the identity of two conditional types over them.
+ */
+type Equals<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+  ? true
+  : false;
+type Assert<T extends true> = T;
+
+/* The four constructor forms, each with and without a trailing config. */
+
+const today = new JDate();
+const fromTuple = new JDate([1396, 8, 26]);
+const fromDate = new JDate(new Date());
+const fromParts = new JDate(1396, 8, 26);
+
+const configOnly = new JDate({ persianNumerical: true });
+const tupleWithConfig = new JDate([1396, 8, 26], { monthNames: ['فروردین'] });
+const dateWithConfig = new JDate(new Date(), { dayNames: [], abbrDays: [] });
+const partsWithConfig = new JDate(1396, 8, 26, { persianNumerical: false });
+
+/* A config the caller does not have is passed as null or undefined, not dropped. */
+const nullConfig = new JDate(new Date(), null);
+const undefinedConfig = new JDate(1396, 8, 26, undefined);
+
+/* Config objects built ahead of time, the shape the README documents. */
+const en = {
+  monthNames: ['Farvardin', 'Ordibehesht'],
+  dayNames: ['Yekshanbe'],
+  abbrDays: ['1sh']
+};
+const fromVariable = new JDate([1396, 8, 26], en);
+const asDeclared: JDateConfig = en;
+
+/* Getters and format() come back as scalars, not as `any`. */
+
+type FullYearIsNumber = Assert<Equals<ReturnType<JDate['getFullYear']>, number>>;
+type MonthIsNumber = Assert<Equals<ReturnType<JDate['getMonth']>, number>>;
+type DateIsNumber = Assert<Equals<ReturnType<JDate['getDate']>, number>>;
+type DayIsNumber = Assert<Equals<ReturnType<JDate['getDay']>, number>>;
+type FormatIsString = Assert<Equals<ReturnType<JDate['format']>, string>>;
+type ToGregorianIsDate = Assert<Equals<ReturnType<JDate['toGregorian']>, Date>>;
+
+/* Instance state. */
+
+type DateFieldIsTuple = Assert<Equals<JDate['date'], JalaliDate>>;
+type InputIsUnion = Assert<Equals<JDate['input'], JalaliDate | Date>>;
+type GregorianFieldIsDate = Assert<Equals<JDate['_d'], Date>>;
+type ConfigIsResolved = Assert<Equals<JDate['config'], ResolvedJDateConfig>>;
+
+/* Statics. */
+
+type ToJalaliIsTuple = Assert<Equals<ReturnType<typeof JDate.toJalali>, JalaliDate>>;
+type ToGregorianStaticIsDate = Assert<Equals<ReturnType<typeof JDate.toGregorian>, Date>>;
+type IsLeapYearIsBoolean = Assert<Equals<ReturnType<typeof JDate.isLeapYear>, boolean>>;
+type DaysInMonthIsNumber = Assert<Equals<ReturnType<typeof JDate.daysInMonth>, number>>;
+type SetDefaultIsResolved = Assert<Equals<ReturnType<typeof JDate.setDefaultConfig>, ResolvedJDateConfig>>;
+
+const jalali: JalaliDate = JDate.toJalali(new Date());
+const gregorian: Date = JDate.toGregorian(1396, 8, 26);
+const leap: boolean = JDate.isLeapYear(1395);
+const length: number = JDate.daysInMonth(1395, 11);
+const resolved: ResolvedJDateConfig = JDate.setDefaultConfig({ persianNumerical: true });
+const current: ResolvedJDateConfig = JDate.getDefaultConfig();
+const restored: ResolvedJDateConfig = JDate.resetDefaultConfig();
+
+/* The deprecated aliases still type-check, so upgrading is not a breaking change. */
+const oldJalali: JalaliDate = JDate.to_jalali(new Date());
+const oldGregorian: Date = JDate.to_gregorian(1396, 8, 26);
+
+/* Setters return the instance, so they chain. */
+const chained: JDate = fromTuple.setFullYear(1397).setMonth(9).setDate(1);
+
+/* A resolved config is frozen at runtime, and readonly here to match. */
+// @ts-expect-error `config` is frozen
+today.config.persianNumerical = true;
+// @ts-expect-error the name lists inside it are frozen too
+today.config.monthNames[0] = 'x';
+
+/* Date forms the runtime does not reject, but does not honour either. */
+// @ts-expect-error a two-element array leaves the day undefined, for an Invalid Date
+const short = new JDate([1396, 8]);
+// @ts-expect-error a fourth entry is silently ignored, so it is a mistake going unheard
+const long = new JDate([1396, 8, 26, 0]);
+// @ts-expect-error two of the three parts
+const missingDay = new JDate(1396, 8);
+
+/*
+ * A trailing null stands in for an absent config only where a whole date is
+ * left beside it — as a lone argument it matches no branch and throws.
+ */
+// @ts-expect-error `new JDate(null)` throws "Unexpected input"
+const nullOnly = new JDate(null);
+
+/* Config arguments the runtime validation rejects. */
+// @ts-expect-error a bare list of names is not a config
+const bareArray = new JDate([1396, 8, 26], ['شنبه']);
+// @ts-expect-error a Date in the config position is not a config
+const dateAsConfig = new JDate([1396, 8, 26], new Date());
+// @ts-expect-error unknown key
+const typo = new JDate({ monthName: [] });
+// @ts-expect-error persianNumerical is strictly boolean, truthiness is not enough
+const truthy = new JDate({ persianNumerical: 'yes' });
+// @ts-expect-error the name lists hold strings
+const numbers = JDate.setDefaultConfig({ monthNames: [1, 2] });
+
+/* Argument types. */
+// @ts-expect-error format takes a format string
+const notAString = today.format(1396);
+// @ts-expect-error the setters take numbers
+const notANumber = today.setFullYear('1396');
+
+/* The ESM bundle exports the class as `default` and nothing else. */
+// @ts-expect-error there is no named JDate binding to import at runtime
+import { JDate as Named } from 'jalali-date';

--- a/tests/types/tsconfig.bundler.json
+++ b/tests/types/tsconfig.bundler.json
@@ -1,0 +1,17 @@
+{
+  /*
+   * The same declarations under the other resolution mode in common use — what
+   * Vite, webpack, esbuild and friends configure. It reads the "exports" map
+   * too, but always takes the "import" condition, so this is the check that
+   * lib/jdate.d.mts is reachable and correct for bundled consumers.
+   *
+   * The .cts fixture is left out: `import = require()` is not valid under
+   * module: esnext.
+   */
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler"
+  },
+  "include": ["bundler.ts"]
+}

--- a/tests/types/tsconfig.json
+++ b/tests/types/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  /*
+   * Type-checks the shipped declarations the way Node resolves the package:
+   * through the "exports" map, so the .mts fixture is matched against
+   * lib/jdate.d.mts and the .cts fixture against lib/jdate.d.cts. A footer
+   * mismatch — the class typed as { default: JDate }, or the other way round —
+   * fails here rather than in a consumer's editor. `npm run test:exports` does
+   * not cover it: it checks that each entry point resolves to types at all, not
+   * what those types export.
+   *
+   * Both fixtures import "jalali-date" by name. TypeScript resolves that to
+   * this package via the self-reference rule, which needs no node_modules link
+   * and, more to the point, goes through the same "exports" map a consumer hits.
+   *
+   * Run after `npm run build`: lib/ is what is being checked.
+   */
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "target": "es2019",
+    "strict": true,
+    "noEmit": true,
+    // The declarations are the subject here, so they are checked rather than
+    // skipped. `"types": []` keeps @types packages a dependency might pull in
+    // out of the picture.
+    "skipLibCheck": false,
+    "types": []
+  },
+  "include": ["node16.mts", "node16.cts"]
+}

--- a/types/jdate.d.ts
+++ b/types/jdate.d.ts
@@ -1,0 +1,210 @@
+/*
+ * The public type surface, hand written and kept in step with src/ by hand.
+ *
+ * This file is a fragment, not a module: it deliberately ends without an export
+ * statement. scripts/build.mjs appends a per-format footer and writes the result
+ * into lib/ three times, because the shape a consumer sees depends on how they
+ * load the package:
+ *
+ *   lib/jdate.d.mts   export default JDate   matches lib/jdate.mjs
+ *   lib/jdate.d.cts   export = JDate         matches lib/jdate.cjs, whose build
+ *                                            footer unwraps .default away
+ *   lib/index.d.ts    export = JDate         the "types" field, for consumers
+ *                                            still on moduleResolution: node
+ *
+ * One shared `export default` would be wrong for two of those three: it would
+ * type `require('jalali-date')` as `{ default: JDate }` when the CJS bundle
+ * hands back the class itself. Nothing about that failure is loud — and it is
+ * past what `npm run test:exports` looks at, which is how the entry points
+ * resolve rather than what they export — so tests/types/node16.cts pins the
+ * shape by requiring the package the way a CommonJS consumer does.
+ *
+ * Types are generated from this file rather than from the JSDoc in src/ because
+ * the constructor is variadic there — `constructor(...args)` would emit
+ * `...args: any[]` and lose the four call forms below, which are the most
+ * useful thing here to type.
+ */
+
+/**
+ * A Jalali date as `[year, month, day]`.
+ *
+ * The month is one based — `1` is فروردین and `12` is اسفند — matching
+ * `getMonth()` and `setMonth()`, though not the zero based
+ * {@link JDate.daysInMonth}.
+ *
+ * The length is part of the type on purpose. `new JDate([1396, 8])` throws
+ * nothing at runtime; it quietly builds an Invalid Date, so the tuple is the
+ * only place that mistake can be caught.
+ */
+type JalaliDate = [year: number, month: number, day: number];
+
+/**
+ * What `format()` prints, layered over the app-wide default by
+ * {@link JDate.setDefaultConfig} or by the last argument to the constructor.
+ * Every key is optional; the ones you leave out keep their built-in values.
+ *
+ * Entry counts are checked at runtime rather than in the type, so that a list
+ * built elsewhere — inferred as `string[]` rather than as a fixed-length tuple —
+ * can still be passed. A wrong length throws at the call site.
+ */
+interface JDateConfig {
+  /** 12 entries in calendar order, فروردین first. */
+  monthNames?: readonly string[];
+  /** 7 entries indexed by `Date#getDay()`, so Sunday first — not Saturday. */
+  dayNames?: readonly string[];
+  /** 7 entries indexed by `Date#getDay()`, so Sunday first — not Saturday. */
+  abbrDays?: readonly string[];
+  /**
+   * Prints the numeric identifiers (`YYYY`, `MM`, `DD`, …) in Persian digits.
+   * Defaults to `false`; the name identifiers are unaffected either way.
+   */
+  persianNumerical?: boolean;
+}
+
+/**
+ * A config with every key filled in. This is what the static config methods
+ * return and what an instance holds as `config` — frozen at construction time,
+ * hence readonly throughout.
+ */
+interface ResolvedJDateConfig {
+  readonly monthNames: readonly string[];
+  readonly dayNames: readonly string[];
+  readonly abbrDays: readonly string[];
+  readonly persianNumerical: boolean;
+}
+
+declare class JDate {
+  /**
+   * Today's date, optionally with display overrides.
+   *
+   * @example new JDate({ persianNumerical: true })
+   */
+  // Not `JDateConfig | null`, unlike the forms below. A trailing null is
+  // dropped only when a whole date is left standing beside it, so `new
+  // JDate(null)` reaches none of the constructor's branches and throws
+  // "Unexpected input" — pass `{}` or nothing. Passing `undefined` explicitly
+  // throws for the same reason and cannot be typed out of reach: TypeScript
+  // lets `undefined` through any optional parameter.
+  constructor(config?: JDateConfig);
+
+  /**
+   * A Jalali date as `[year, month, day]` with a one-based month, or a
+   * Gregorian `Date` to convert.
+   *
+   * @example new JDate([1396, 8, 26])
+   * @example new JDate(new Date(), { monthNames })
+   */
+  constructor(date: JalaliDate | Date, config?: JDateConfig | null);
+
+  /**
+   * A Jalali date as three numbers, with a one-based month.
+   *
+   * @example new JDate(1396, 8, 26)
+   */
+  constructor(year: number, month: number, day: number, config?: JDateConfig | null);
+
+  /** The Jalali date as `[year, month, day]`. The setters write through to it. */
+  date: JalaliDate;
+
+  /**
+   * What the constructor was given, with any config argument stripped. The
+   * setters do not touch it, so it still reflects the original input after a
+   * `setMonth()`.
+   */
+  input: JalaliDate | Date;
+
+  /** The Gregorian equivalent, kept in sync by the setters. */
+  _d: Date;
+
+  /** The frozen display options this instance formats with. */
+  readonly config: ResolvedJDateConfig;
+
+  /** The Gregorian equivalent of this instance's date. */
+  toGregorian(): Date;
+
+  /** The Jalali year, ex: `1396`. */
+  getFullYear(): number;
+
+  /** Returns this instance, so setters chain. */
+  setFullYear(year: number): this;
+
+  /** The Jalali month, `1` to `12`. Unlike `Date#getMonth`, this is one based. */
+  getMonth(): number;
+
+  /**
+   * Sets the Jalali month. Unlike `Date#setMonth`, this is one based; values
+   * outside `1..12` roll the year over, so `setMonth(13)` is month `1` of the
+   * following year.
+   *
+   * @returns this instance, so setters chain.
+   */
+  setMonth(month: number): this;
+
+  /** The Jalali day of the month, `1` to `31`. */
+  getDate(): number;
+
+  /** Returns this instance, so setters chain. */
+  setDate(date: number): this;
+
+  /** The day of the week, `0` (Sunday) to `6` (Saturday), as `Date#getDay`. */
+  getDay(): number;
+
+  /**
+   * Formats the date. Identifiers: `YYYY`/`YYY`, `YY`, `MMMM`/`MMM`, `MM`, `M`,
+   * `DD`, `D`, `dddd`/`ddd`, `dd`/`d`. Anything else passes through, so wrap
+   * literal text containing an identifier character in square brackets —
+   * `format('[Day] D')`.
+   *
+   * The name identifiers resolve against this instance's config, which also
+   * decides whether the numeric ones print in ASCII or Persian digits.
+   *
+   * @example jdate.format('dddd DD MMMM YYYY') // => جمعه 26 آبان 1396
+   */
+  format(format: string): string;
+
+  /**
+   * Overrides what every later instance formats with. Replaces the default
+   * rather than merging into a previous call, so the result depends only on
+   * what you pass. Throws on an unknown key or a wrong-shaped value.
+   *
+   * Existing instances keep the config they captured at construction time.
+   */
+  static setDefaultConfig(config: JDateConfig): ResolvedJDateConfig;
+
+  /** The frozen config new instances will pick up. */
+  static getDefaultConfig(): ResolvedJDateConfig;
+
+  /** Restores the built-in Persian names and ASCII numerals. */
+  static resetDefaultConfig(): ResolvedJDateConfig;
+
+  /** Converts a Gregorian `Date` to a Jalali `[year, month, day]`. */
+  static toJalali(date: Date): JalaliDate;
+
+  /**
+   * @deprecated Renamed to {@link JDate.toJalali}; this alias is kept only for
+   * backwards compatibility.
+   */
+  static to_jalali(date: Date): JalaliDate;
+
+  /** Converts a Jalali date, with a one-based month, to a Gregorian `Date`. */
+  static toGregorian(year: number, month: number, day: number): Date;
+
+  /**
+   * @deprecated Renamed to {@link JDate.toGregorian}; this alias is kept only
+   * for backwards compatibility.
+   */
+  static to_gregorian(year: number, month: number, day: number): Date;
+
+  /** Whether a Jalali year is a leap year. */
+  static isLeapYear(year: number): boolean;
+
+  /**
+   * The length of a Jalali month.
+   *
+   * Note: `month` is **zero based** here (`0` is فروردین, `11` is اسفند),
+   * unlike `getMonth`/`setMonth`, so it does not compose directly with
+   * `getMonth()` — `daysInMonth(d.getFullYear(), d.getMonth() - 1)`.
+   * Out-of-range values carry into the year.
+   */
+  static daysInMonth(year: number, month: number): number;
+}


### PR DESCRIPTION
Makes the package usable from TypeScript without converting it to TypeScript. The library stays JavaScript; the declarations are hand written in `types/jdate.d.ts` and emitted into `lib/` by the build.

```typescript
import JDate, { type JalaliDate, type JDateConfig } from 'jalali-date';

const jdate = new JDate([1396, 8, 26], { persianNumerical: true });
const formatted: string = jdate.format('dddd DD MMMM YYYY');
```

## Why not generate them from the JSDoc

`tsc --allowJs --emitDeclarationOnly` was the obvious route and does not work here. The comments in `src/` use `@params`, which tsc ignores, so every one would need rewriting; and the constructor is variadic, so `constructor(...args)` emits `...args: any[]` and loses the four call forms — the most useful thing in the file to type. Hand writing costs a second source of truth, which is what the two checks below are for.

## One declaration cannot describe both bundles

`lib/jdate.cjs` ends with `module.exports = module.exports.default`, so `require()` returns the class itself and its declaration must say `export = JDate`. `lib/jdate.mjs` exports the class as `default` and needs `export default`. A single shared `export default` file would type `require('jalali-date')` as `{ default: JDate }` — wrong, and silently so.

So `types/jdate.d.ts` is a body with no export statement, and the build appends one of two footers, the same way it already appends footers to the JS bundles:

| Emitted | Footer | Matches |
| --- | --- | --- |
| `lib/jdate.d.mts` | `export default JDate` | `lib/jdate.mjs` |
| `lib/jdate.d.cts` | `export = JDate` | `lib/jdate.cjs` |
| `lib/index.d.ts` | `export = JDate` | the top-level `"types"` field |

`export =` forbids any other top-level export, so the CJS side re-exports the type names through a namespace merged into the class (`JDate.JDateConfig`).

`lib/index.d.ts` looks redundant beside `jdate.d.cts` and is not: TypeScript did not learn the `.d.cts` extension until 4.7, so pointing `"types"` straight at that file leaves every older version with no types at all — 4.6 reports `Could not find a declaration file for module 'jalali-date'`.

## Two checks, both in CI after the build

- **`npm run test:types`** — compiles `tests/types/` against the shipped declarations under both resolution modes in common use: `nodenext` (which tells the `.mts` and `.cts` fixtures apart) and `bundler`.
- **`npm run test:exports`** — runs `attw` over the packed tarball.

Neither is redundant. attw checks that every entry point resolves to types and that no format masquerades as another, but it does not look at what those types *export*: swapping the CJS footer for the ESM one leaves attw fully green, while the `.cts` fixture fails immediately with `This expression is not constructable`. Verified by doing it.

## API notes

The constructor is three overloads covering the four call forms. `JalaliDate` is a three-element tuple rather than `number[]` on purpose — `new JDate([1396, 8])` throws nothing at runtime, it quietly builds an Invalid Date, so the arity is the only place that mistake can be caught. Config entry counts stay a runtime check, because a name list built elsewhere infers as `string[]` rather than as a tuple and should still be passable; the README's own example is that shape.

Reviewing the declarations against the runtime found one defect in them: the config-only overload had been given `config?: JDateConfig | null`, copied from the other two. A trailing null is dropped only when a whole date is left standing beside it, so `new JDate(null)` reaches no branch and throws `Unexpected input` — and `new JDate(maybeConfig)` on a nullable variable would have compiled clean and thrown in production. Fixed, with a fixture pinning it.

## Verification

Packed the tarball, installed it into a scratch project and type-checked it as a real dependency: **TS 6** (nodenext ESM, nodenext CJS, bundler), **TS 5.9** (nodenext, legacy `node`), **TS 4.6** (legacy `node`) — all clean. Runtime agrees with the declarations: `require()` yields `function JDate` with no `.default`, the ESM default import yields the class.

A fresh `npm run build` leaves the tree clean, so the checked-in `lib/` declarations are exactly reproducible from source.

**No runtime code changed.** The 101 tests and the four JS bundles are byte for byte what they were.

## Not included

Nothing asserts that the *built bundles* still have the export shapes the declarations claim — if a build footer changed, types and reality would drift silently. A smoke test importing `lib/jdate.cjs` and `lib/jdate.mjs` would close that, but it makes `npm test` depend on a prior build, so it is left out of this change.
